### PR TITLE
Migrate to new API

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -13,44 +13,36 @@ export default class Client {
       ...config,
     });
     this.headers = { Authorization: config.token };
-    this.events = {
-      data: api.PUBLISH_DATA,
-      getData: api.REQUEST_DATA,
-      setData: api.UPDATE_DATA,
-    };
     this.userKey = uniqid();
   }
 
-  async subscribeToResponse(resolve, reject, reqKey, resKey, msg) {
-    const reqExchange = api.getExchange(reqKey);
-    const resExchange = api.getExchange(resKey);
-    const queue = `${resKey}-${this.userKey}`;
+  async subscribeToResponse(resolve, reject, req, resp, message) {
+    const queue = `${resp.key}-${this.userKey}`;
     const consumerTag = uniqid.time(`${queue}-`);
-
-    const handleResponse = async ({ error, ...message }) => {
-      if (message.id === msg.id) {
+    const handler = async ({ error, ...reply }) => {
+      if (reply.id === message.id) {
         await this.amqp.unsubscribeConsumer(consumerTag);
         if (error) {
           reject(Error(error));
         } else {
-          resolve(message);
+          resolve(reply);
         }
       }
     };
-
-    await this.amqp.subscribeTo(resExchange, resKey, queue, handleResponse, { consumerTag });
-    await this.amqp.publishMessage(reqExchange, reqKey, msg, this.headers);
+    await this.amqp.subscribeTo(resp.name, resp.type, resp.key, queue, handler, { consumerTag });
+    await this.amqp.publishMessage(req.name, req.type, req.key, message, this.headers);
   }
 
-  async sendRequest(routingKey, message) {
-    const responseKey = api.getResponseKey(routingKey);
-    if (responseKey) {
-      return new Promise((resolve, reject) => {
-        this.subscribeToResponse(resolve, reject, routingKey, responseKey, message);
-      });
-    }
-    const exchange = api.getExchange(routingKey);
-    return this.amqp.publishMessage(exchange, routingKey, message, this.headers);
+  async sendRequest(req, resp, message) {
+    return new Promise((resolve, reject) => (
+      this.subscribeToResponse(resolve, reject, req, resp, message)
+    ));
+  }
+
+  setReplyOptions() {
+    const correlationId = uniqid();
+    this.headers['correlation-id'] = correlationId;
+    return correlationId;
   }
 
   async connect() {
@@ -63,22 +55,38 @@ export default class Client {
 
   async register(id, name) {
     const msg = { id, name };
-    return this.sendRequest(api.REGISTER_DEVICE, msg);
+    const req = api.getDefinitionByKey(api.REGISTER_DEVICE);
+    const resp = { name: req.name, type: req.type, key: api.getResponseKey(api.REGISTER_DEVICE) };
+    return this.sendRequest(req, resp, msg);
   }
 
   async unregister(id) {
     const msg = { id };
-    return this.sendRequest(api.UNREGISTER_DEVICE, msg);
+    const req = api.getDefinitionByKey(api.UNREGISTER_DEVICE);
+    const resp = { name: req.name, type: req.type, key: api.getResponseKey(api.UNREGISTER_DEVICE) };
+    return this.sendRequest(req, resp, msg);
+  }
+
+  async authDevice(id) {
+    const msg = { id };
+    const correlationId = this.setReplyOptions();
+    const req = api.getDefinitionByKey(api.AUTH_DEVICE);
+    const resp = { name: req.name, type: req.type, key: correlationId };
+    return this.sendRequest(req, resp, msg);
   }
 
   async getDevices() {
-    const msg = {};
-    return this.sendRequest(api.LIST_DEVICES, msg);
+    const correlationId = this.setReplyOptions();
+    const req = api.getDefinitionByKey(api.LIST_DEVICES);
+    const resp = { name: req.name, type: req.type, key: correlationId };
+    return this.sendRequest(req, resp, {});
   }
 
   async updateSchema(id, schemaList) {
     const msg = { id, schema: schemaList };
-    return this.sendRequest(api.UPDATE_SCHEMA, msg);
+    const req = api.getDefinitionByKey(api.UPDATE_SCHEMA);
+    const resp = { name: req.name, type: req.type, key: api.getResponseKey(api.UPDATE_SCHEMA) };
+    return this.sendRequest(req, resp, msg);
   }
 
   async publishData(id, dataList) {

--- a/src/Client.js
+++ b/src/Client.js
@@ -91,17 +91,19 @@ export default class Client {
 
   async publishData(id, dataList) {
     const msg = { id, data: dataList };
-    return this.sendRequest(api.PUBLISH_DATA, msg);
+    return this.amqp.publishMessage(api.DATA_SENT_EXCHANGE, api.DATA_SENT_EXCHANGE_TYPE, '', msg, this.headers);
   }
 
   async getData(id, sensorIds) {
     const msg = { id, sensorIds };
-    return this.sendRequest(api.REQUEST_DATA, msg);
+    const req = api.getDefinitionByKey(api.REQUEST_DATA);
+    return this.amqp.publishMessage(req.name, req.type, req.key, msg, this.headers);
   }
 
   async setData(id, dataList) {
     const msg = { id, data: dataList };
-    return this.sendRequest(api.UPDATE_DATA, msg);
+    const req = api.getDefinitionByKey(api.UPDATE_DATA);
+    return this.amqp.publishMessage(req.name, req.type, req.key, msg, this.headers);
   }
 
   async on(event, callback, options) {

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -42,11 +42,11 @@ const responses = {
   [UPDATE_SCHEMA]: UPDATE_SCHEMA_RESPONSE,
 };
 
-export const getExchange = (key) => {
-  const [name] = Object
+export const getDefinitionByKey = (key) => {
+  const [name, args] = Object
     .entries(requestExchanges)
     .find(([, obj]) => obj.keys.includes(key)) || [];
-  return name;
+  return { name, type: args.type, key };
 };
 
 export const getResponseKey = (key) => responses[key];

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -2,48 +2,51 @@
 
 export const REGISTER_DEVICE = 'device.register';
 export const UNREGISTER_DEVICE = 'device.unregister';
-export const LIST_DEVICES = 'device.cmd.list';
-export const UPDATE_SCHEMA = 'schema.update';
-export const PUBLISH_DATA = 'data.publish';
-
+export const AUTH_DEVICE = 'device.auth';
+export const LIST_DEVICES = 'device.list';
+export const UPDATE_SCHEMA = 'device.schema.sent';
+export const PUBLISH_DATA = 'data.published';
 export const REGISTER_DEVICE_RESPONSE = 'device.registered';
 export const UNREGISTER_DEVICE_RESPONSE = 'device.unregistered';
-export const LIST_DEVICES_RESPONSE = 'device.list';
-export const UPDATE_SCHEMA_RESPONSE = 'schema.updated';
+export const UPDATE_SCHEMA_RESPONSE = 'device.schema.updated';
 export const REQUEST_DATA = 'data.request';
 export const UPDATE_DATA = 'data.update';
 
-const exchanges = {
-  fogIn: [
-    REGISTER_DEVICE,
-    UNREGISTER_DEVICE,
-    LIST_DEVICES,
-    UPDATE_SCHEMA,
-    PUBLISH_DATA,
-  ],
-  fogOut: [
-    REGISTER_DEVICE_RESPONSE,
-    UNREGISTER_DEVICE_RESPONSE,
-    LIST_DEVICES_RESPONSE,
-    UPDATE_SCHEMA_RESPONSE,
-  ],
-  connOut: [
-    REQUEST_DATA,
-    UPDATE_DATA,
-  ],
+export const DEVICE_EXCHANGE = 'device';
+export const DEVICE_EXCHANGE_TYPE = 'direct';
+
+export const DATA_SENT_EXCHANGE = 'data.sent';
+export const DATA_SENT_EXCHANGE_TYPE = 'fanout';
+
+const requestExchanges = {
+  [DEVICE_EXCHANGE]: {
+    type: DEVICE_EXCHANGE_TYPE,
+    keys: [
+      AUTH_DEVICE,
+      LIST_DEVICES,
+      REGISTER_DEVICE,
+      REGISTER_DEVICE_RESPONSE,
+      UNREGISTER_DEVICE,
+      UNREGISTER_DEVICE_RESPONSE,
+      UPDATE_SCHEMA,
+      UPDATE_SCHEMA_RESPONSE,
+      REQUEST_DATA,
+      UPDATE_DATA,
+    ],
+  },
 };
 
 const responses = {
   [REGISTER_DEVICE]: REGISTER_DEVICE_RESPONSE,
   [UNREGISTER_DEVICE]: UNREGISTER_DEVICE_RESPONSE,
-  [LIST_DEVICES]: LIST_DEVICES_RESPONSE,
   [UPDATE_SCHEMA]: UPDATE_SCHEMA_RESPONSE,
 };
 
 export const getExchange = (key) => {
-  const [exchange] = Object.entries(exchanges)
-    .find(([, keys]) => keys.includes(key)) || [];
-  return exchange;
+  const [name] = Object
+    .entries(requestExchanges)
+    .find(([, obj]) => obj.keys.includes(key)) || [];
+  return name;
 };
 
 export const getResponseKey = (key) => responses[key];

--- a/src/network/AMQP.js
+++ b/src/network/AMQP.js
@@ -21,7 +21,7 @@ export default class AMQP {
     await this.connection.close();
   }
 
-  async declareExchange(exchange, type = 'topic', options = { durable: true }) {
+  async declareExchange(exchange, type, options = { durable: true }) {
     await this.channel.assertExchange(exchange, type, options);
   }
 
@@ -30,14 +30,14 @@ export default class AMQP {
     await this.channel.bindQueue(queue, exchange, routingKey);
   }
 
-  async publishMessage(exchange, routingKey, message, headers) {
-    await this.declareExchange(exchange);
+  async publishMessage(exchange, type, routingKey, message, headers) {
+    await this.declareExchange(exchange, type);
     this.channel.publish(exchange, routingKey, Buffer.from(JSON.stringify(message)), { headers });
   }
 
-  async subscribeTo(exchange, routingKey, queue, onMessage, options) {
+  async subscribeTo(exchange, type, routingKey, queue, onMessage, options) {
     const callback = (msg) => onMessage(JSON.parse(msg.content.toString()));
-    await this.declareExchange(exchange);
+    await this.declareExchange(exchange, type);
     await this.bindQueue(queue, exchange, routingKey);
     return this.channel.consume(queue, callback, options);
   }


### PR DESCRIPTION
**Describe what this PR introduces:**

This patch set adapts the AMQP SDK for the new [API](https://github.com/CESARBR/knot-babeltower/blob/master/docs/events.md). For that to be possible, it was necessary to refactor the code to avoid unnecessary abstractions and support sending/receiving messages of different exchange types.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix
- [ ] Feature
- [ ] Code style update
- [X] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [X] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

As this PR aims to adapt the SDK to a different API version, the developers must be running the newer versions of our KNoT Cloud Stack. In terms of usability, there's no huge impact. The operations signature remains the same.

**The PR fulfills these requirements:**

- [ ] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

**Testing environment:**

- Operating System/Platform: macOs - Darwin
- Node version: v12.16.2
- Yarn version: v1.16.0
