### PR TITLE
Add reply_to property

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -40,9 +40,10 @@ class Client {
   }
 
   setReplyOptions() {
-    const correlationId = uniqid();
-    this.headers['correlation-id'] = correlationId;
-    return correlationId;
+    const replyTo = uniqid();
+    this.headers.reply_to = replyTo;
+    this.headers.correlation_id = '';
+    return replyTo;
   }
 
   async connect() {
@@ -69,16 +70,16 @@ class Client {
 
   async authDevice(id) {
     const msg = { id };
-    const correlationId = this.setReplyOptions();
+    const replyTo = this.setReplyOptions();
     const req = api.getDefinitionByKey(api.AUTH_DEVICE);
-    const resp = { name: req.name, type: req.type, key: correlationId };
+    const resp = { name: req.name, type: req.type, key: replyTo };
     return this.sendRequest(req, resp, msg);
   }
 
   async getDevices() {
-    const correlationId = this.setReplyOptions();
+    const replyTo = this.setReplyOptions();
     const req = api.getDefinitionByKey(api.LIST_DEVICES);
-    const resp = { name: req.name, type: req.type, key: correlationId };
+    const resp = { name: req.name, type: req.type, key: replyTo };
     return this.sendRequest(req, resp, {});
   }
 


### PR DESCRIPTION
**Describe what this PR introduces:**

When sending request-reply messages, the header property that guarantees the response delivery should be called `reply_to` instead of `correlation-id`.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bug fix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing
- [ ] New/updated tests are included

**Testing environment:**

- Operating System/Platform: macOS Darwin 18.0.0
- Node version: v12.16.2
- Yarn version: 1.16.0